### PR TITLE
Include headings from various Wikis in documentation structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,53 @@
 The Hubs documentation site has several different types of content that covers both Hubs and Spoke. Please keep the following structure in mind when creating new documentation files for the site. 
 
 * Getting Started Guides
-  - Guide #1
-  - Guide #2
+  - Guide #1 - Getting Started With Hubs 
+  - Guide #2 - Building a Scene with Spoke
 * Hubs Reference
-  - (Example) User controls
-  - (Example) User list
-  - (Example) Object list 
+  - Scenes
+    - Scene Browser
+    - Lobbies and Rooms
+    - Sharing Invites
+    - Receiving Invites
+    - User List
+    - Chat
+    - Notifications
+    - Name
+    - Entering a Room
+    - Entering on a Mobile VR Headset
+  - In Room Experience
+    - Moving Around
+      - Fly Mode
+    - Growing and Shrinking
+    - Muting
+    - Adding video, audio, 3D models and images
+    - Moving Objects
+    - Menus
+    - Pinning
+    - Blocking
+    - Using Chat
+    - Using the Camera
+    - Mirror Mode
+    - Focus and Track Mode
+    - Using the Pen
+    - Sharing Your Screen or Phone/Web Cam
+    - Controls
+    - User List
+    - Object list
+    - Moderating rooms
+    - Customizing Avatars
+    - Discord Integration
+
 * Spoke Reference
-  - (Example) Asset Panel
+  - Lighting and shadows
+  - Physics and Navigation
+  - Creating Assets for Spoke
+  - Using Spoke Scenes in your own Projects
+  - Keyboard and Mouse Controls
+  - (Example) Asset panel
   - (Example) Element Properties
+
 * For Developers
-  - (Example) Source Code
-  - (Example) Contributing to Hubs and Spoke
+  - Hubs system overview
+  - (Example) source code
+  - (Example contributing to Hubs and spoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Content Structure
+The Hubs documentation site has several different types of content that covers both Hubs and Spoke. Please keep the following structure in mind when creating new documentation files for the site. 
+
+* Getting Started Guides
+  - Guide #1
+  - Guide #2
+* Hubs Reference
+  - (Example) User controls
+  - (Example) User list
+  - (Example) Object list 
+* Spoke Reference
+  - (Example) Asset Panel
+  - (Example) Element Properties
+* For Developers
+  - (Example) Source Code
+  - (Example) Contributing to Hubs and Spoke


### PR DESCRIPTION
Adding a bit more detail to the proposed structure by including the headings from the various Hubs wikis as a starting point